### PR TITLE
Change to the new artifactory domain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- release parent settings -->
-        <nexus.snapshot.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/
+        <nexus.snapshot.repository>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/
         </nexus.snapshot.repository>
-        <nexus.release.repository>https://app.camunda.com/nexus/content/repositories/zeebe-io/
+        <nexus.release.repository>https://artifacts.camunda.com/artifactory/zeebe-io/
         </nexus.release.repository>
 
         <plugin.version.javadoc>3.1.1</plugin.version.javadoc>
@@ -249,7 +249,7 @@
         <repository>
             <id>zeebe</id>
             <name>Zeebe Repository</name>
-            <url>https://app.camunda.com/nexus/content/repositories/zeebe-io/</url>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
@@ -261,7 +261,7 @@
         <repository>
             <id>zeebe-snapshots</id>
             <name>Zeebe Snapshot Repository</name>
-            <url>https://app.camunda.com/nexus/content/repositories/zeebe-io-snapshots/</url>
+            <url>https://artifacts.camunda.com/artifactory/zeebe-io-snapshots/</url>
             <releases>
                 <enabled>false</enabled>
             </releases>


### PR DESCRIPTION
We created a new domain name for our repository manager (Artifactory) to replace the old Nexus proxy URL (app.camunda.com/nexus). The proxy URL will be removed in the future. 

Related to INFRA-3114



