### PR TITLE
Fix service name in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9600:9600"
     networks:
       - zeebe_network
-  monitor:
+  zeebe-script-worker:
     container_name: zeebe-script-worker
     image: ghcr.io/camunda-community-hub/zeebe-script-worker:1.0.0
     environment:


### PR DESCRIPTION
The `docker-compose.yml` file contained a mention of `monitor` as service name for the `zeebe-script-worker`. This is probably a copy paste error, and confused me for a second.